### PR TITLE
Correct HRTimer_Prescaler values.

### DIFF
--- a/ADL/drivers/stm32-hrtimers.ads
+++ b/ADL/drivers/stm32-hrtimers.ads
@@ -95,14 +95,14 @@ package STM32.HRTimers is
    --  "Clocks".
 
    for HRTimer_Prescaler use
-     (Div_1   => 1,
-      Div_2   => 2,
-      Div_4   => 4,
-      Div_8   => 8,
-      Div_16  => 16,
-      Div_32  => 32,
-      Div_64  => 64,
-      Div_128 => 128);
+     (Div_1   => 2#000#,
+      Div_2   => 2#001#,
+      Div_4   => 2#010#,
+      Div_8   => 2#011#,
+      Div_16  => 2#100#,
+      Div_32  => 2#101#,
+      Div_64  => 2#110#,
+      Div_128 => 2#111#);
 
    procedure Configure_Prescaler
      (This        : in out HRTimer_Master;
@@ -2452,4 +2452,3 @@ private
      with Import, Address => HRTIM_Common_Base;
 
 end STM32.HRTimers;
-

--- a/ADL/drivers/stm32g474/stm32-hrtimers.ads
+++ b/ADL/drivers/stm32g474/stm32-hrtimers.ads
@@ -95,14 +95,14 @@ package STM32.HRTimers is
    --  "Clocks".
 
    for HRTimer_Prescaler use
-     (Div_1   => 1,
-      Div_2   => 2,
-      Div_4   => 4,
-      Div_8   => 8,
-      Div_16  => 16,
-      Div_32  => 32,
-      Div_64  => 64,
-      Div_128 => 128);
+     (Div_1   => 2#000#,
+      Div_2   => 2#001#,
+      Div_4   => 2#010#,
+      Div_8   => 2#011#,
+      Div_16  => 2#100#,
+      Div_32  => 2#101#,
+      Div_64  => 2#110#,
+      Div_128 => 2#111#);
 
    procedure Configure_Prescaler
      (This        : in out HRTimer_Master;
@@ -2452,4 +2452,3 @@ private
      with Import, Address => HRTIM_Common_Base;
 
 end STM32.HRTimers;
-


### PR DESCRIPTION
This PR changes the enumeration representation of HRTimer_Prescaler to match the values given by Table 216 in RM0440 Rev 8. This is required for Configure_Prescaler and Current_Prescaler to function correctly.