### PR TITLE
Remove erroneous enabling of DMA before configuration.

### DIFF
--- a/ADL/drivers/stm32-dma.adb
+++ b/ADL/drivers/stm32-dma.adb
@@ -860,8 +860,6 @@ package body STM32.DMA is
       --  we must disable the stream before configuring it
       Disable (This, Stream);
 
-      This_Stream.CR.EN := True;
-
       if This'Address = DMA1_Periph'Address then
          case Stream is
             when Stream_1 =>

--- a/ADL/drivers/stm32g474/stm32-dma.adb
+++ b/ADL/drivers/stm32g474/stm32-dma.adb
@@ -860,8 +860,6 @@ package body STM32.DMA is
       --  we must disable the stream before configuring it
       Disable (This, Stream);
 
-      This_Stream.CR.EN := True;
-
       if This'Address = DMA1_Periph'Address then
          case Stream is
             when Stream_1 =>


### PR DESCRIPTION
As noted in the manual referenced in the comment (and in 12.6.3 of RM0440 Rev 8 for the G474), some of the fields set by this procedure are read-only when the stream is enabled. This line also causes the post-condition on the procedure to fail. This error also exists in your other libraries.