### PR TITLE
Fix various uses of 'Val that should be 'Enum_Val.

### DIFF
--- a/ADL/devices/stm32-device.adb
+++ b/ADL/devices/stm32-device.adb
@@ -1369,7 +1369,7 @@ package body STM32.Device is
    function System_Clock_Frequencies return RCC_System_Clocks
    is
       Source : constant SYSCLK_Clock_Source :=
-        SYSCLK_Clock_Source'Val (RCC_Periph.CFGR.SWS);
+        SYSCLK_Clock_Source'Enum_Val (RCC_Periph.CFGR.SWS);
       --  Get System_Clock_Mux selection
 
       Result : RCC_System_Clocks;

--- a/ADL/drivers/stm32-adc.adb
+++ b/ADL/drivers/stm32-adc.adb
@@ -527,12 +527,12 @@ package body STM32.ADC is
       then
          This.CR.ADSTART := True;
       elsif This'Address = ADC2_Base then --  slave channel
-         if Multi_ADC_Mode_Selections'Val (ADC12_Common_Periph.CCR.DUAL) = Independent
+         if Multi_ADC_Mode_Selections'Enum_Val (ADC12_Common_Periph.CCR.DUAL) = Independent
          then
             This.CR.ADSTART := True;
          end if;
       elsif This'Address = ADC4_Base then --  slave channel
-         if Multi_ADC_Mode_Selections'Val (ADC345_Common_Periph.CCR.DUAL) = Independent
+         if Multi_ADC_Mode_Selections'Enum_Val (ADC345_Common_Periph.CCR.DUAL) = Independent
          then
             This.CR.ADSTART := True;
          end if;

--- a/ADL/drivers/stm32-fmac.adb
+++ b/ADL/drivers/stm32-fmac.adb
@@ -175,7 +175,7 @@ package body STM32.FMAC is
      (This : FMAC_Accelerator) return FMAC_Function
    is
    begin
-      return FMAC_Function'Val (This.PARAM.FUNC);
+      return FMAC_Function'Enum_Val (This.PARAM.FUNC);
    end Read_Function;
 
    ----------------------

--- a/ADL/drivers/stm32-opamp.adb
+++ b/ADL/drivers/stm32-opamp.adb
@@ -205,7 +205,7 @@ package body STM32.OPAMP is
    function Get_PGA_Mode_Gain
      (This : Operational_Amplifier) return PGA_Mode_Gain is
    begin
-      return PGA_Mode_Gain'Val (This.CSR.PGA_GAIN);
+      return PGA_Mode_Gain'Enum_Val (This.CSR.PGA_GAIN);
    end Get_PGA_Mode_Gain;
 
    --------------------

--- a/ADL/drivers/stm32g474/stm32-adc.adb
+++ b/ADL/drivers/stm32g474/stm32-adc.adb
@@ -527,12 +527,12 @@ package body STM32.ADC is
       then
          This.CR.ADSTART := True;
       elsif This'Address = ADC2_Base then --  slave channel
-         if Multi_ADC_Mode_Selections'Val (ADC12_Common_Periph.CCR.DUAL) = Independent
+         if Multi_ADC_Mode_Selections'Enum_Val (ADC12_Common_Periph.CCR.DUAL) = Independent
          then
             This.CR.ADSTART := True;
          end if;
       elsif This'Address = ADC4_Base then --  slave channel
-         if Multi_ADC_Mode_Selections'Val (ADC345_Common_Periph.CCR.DUAL) = Independent
+         if Multi_ADC_Mode_Selections'Enum_Val (ADC345_Common_Periph.CCR.DUAL) = Independent
          then
             This.CR.ADSTART := True;
          end if;

--- a/ADL/drivers/stm32g474/stm32-fmac.adb
+++ b/ADL/drivers/stm32g474/stm32-fmac.adb
@@ -175,7 +175,7 @@ package body STM32.FMAC is
      (This : FMAC_Accelerator) return FMAC_Function
    is
    begin
-      return FMAC_Function'Val (This.PARAM.FUNC);
+      return FMAC_Function'Enum_Val (This.PARAM.FUNC);
    end Read_Function;
 
    ----------------------

--- a/ADL/drivers/stm32g474/stm32-opamp.adb
+++ b/ADL/drivers/stm32g474/stm32-opamp.adb
@@ -205,7 +205,7 @@ package body STM32.OPAMP is
    function Get_PGA_Mode_Gain
      (This : Operational_Amplifier) return PGA_Mode_Gain is
    begin
-      return PGA_Mode_Gain'Val (This.CSR.PGA_GAIN);
+      return PGA_Mode_Gain'Enum_Val (This.CSR.PGA_GAIN);
    end Get_PGA_Mode_Gain;
 
    --------------------


### PR DESCRIPTION
Most of these changes are straightforward aside from stm32-adc.adb. In that file the usage of 'Val would likely usually be harmless but it can raise a Constraint_Error if Range_Check is enabled.

These errors may exist in your other libraries, I have not checked. One of the errors came from AdaCore's library.