### PR TITLE
Wait for STM32 timer output to be enabled before returning from enable procedure.

### DIFF
--- a/ADL/drivers/stm32-timers.adb
+++ b/ADL/drivers/stm32-timers.adb
@@ -1382,6 +1382,10 @@ package body STM32.Timers is
    procedure Enable_Main_Output (This : in out Timer) is
    begin
       This.BDTR.Main_Output_Enabled := True;
+
+      loop
+         exit when Main_Output_Enabled (This);
+      end loop;
    end Enable_Main_Output;
 
    -------------------------

--- a/ADL/drivers/stm32g474/stm32-timers.adb
+++ b/ADL/drivers/stm32g474/stm32-timers.adb
@@ -1382,6 +1382,10 @@ package body STM32.Timers is
    procedure Enable_Main_Output (This : in out Timer) is
    begin
       This.BDTR.Main_Output_Enabled := True;
+
+      loop
+         exit when Main_Output_Enabled (This);
+      end loop;
    end Enable_Main_Output;
 
    -------------------------


### PR DESCRIPTION
RM0440 Rev 8 28.3.18 notes that there may be a delay before the BDTR.MOE bit reads as 1 after writing to it. The RM says that only a single instruction is needed, but testing has shown that this is incorrect.

With the previous code, calling Enable_Main_Output and then immediately calling a procedure to set a different part of the register could result in the MOE bit being inadvertently set low.